### PR TITLE
Add Linux installers to release workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -87,6 +87,43 @@ jobs:
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
 
+      - name: Setup | Python
+        if: steps.release.outputs.released == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup | Install system dependencies for Briefcase
+        if: steps.release.outputs.released == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            build-essential \
+            gir1.2-gtk-3.0 \
+            libcairo2-dev \
+            libgirepository1.0-dev \
+            libgtk-3-dev \
+            libpango1.0-dev \
+            patchelf \
+            pkg-config \
+            python3-dev \
+            rpm
+
+      - name: Setup | Install Briefcase
+        if: steps.release.outputs.released == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install briefcase
+
+      - name: Build | Linux packages
+        if: steps.release.outputs.released == 'true'
+        run: |
+          # Debian packaging requires a build step before packaging; Fedora
+          # uses the previously generated app bundle.
+          briefcase build linux --target debian --update
+          briefcase package linux --target debian --update
+          briefcase package linux --target fedora --update
+
       - name: Publish | Upload to GitHub Release Assets
         uses: python-semantic-release/publish-action@v10.4.1
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Summary
- install required system and Python dependencies when a release is triggered
- build Debian and Fedora packages with Briefcase so the artifacts are attached to the release

## Testing
- not run (CI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d9100f4340832ba8fbddb5ecec410a