### PR TITLE
Ensure audio pre-init runs before pygame init

### DIFF
--- a/src/fretsonfire/GameEngine.py
+++ b/src/fretsonfire/GameEngine.py
@@ -138,12 +138,9 @@ class GameEngine(Engine):
     tickrate     = self.config.get("engine", "tickrate")
     Engine.__init__(self, fps = fps, tickrate = tickrate)
     
-    pygame.init()
-    
     self.title             = _("Frets on Fire")
     self.restartRequested  = False
     self.handlingException = False
-    self.video             = Video(self.title)
     self.audio             = Audio()
 
     Log.debug("Initializing audio.")
@@ -151,9 +148,10 @@ class GameEngine(Engine):
     bits         = self.config.get("audio", "bits")
     stereo       = self.config.get("audio", "stereo")
     bufferSize   = self.config.get("audio", "buffersize")
-    
+
     self.audio.pre_open(frequency = frequency, bits = bits, stereo = stereo, bufferSize = bufferSize)
     pygame.init()
+    self.video             = Video(self.title)
     self.audio.open(frequency = frequency, bits = bits, stereo = stereo, bufferSize = bufferSize)
 
     Log.debug("Initializing video.")


### PR DESCRIPTION
## Summary
- run the audio pre-initialisation before pygame initialises to keep mixer configuration intact
- instantiate the video subsystem after pygame has been brought up so the library initialises only once

## Testing
- SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy python - <<'PY'
import sys
sys.path.insert(0, 'src')
from fretsonfire.Audio import Audio
import pygame

audio = Audio()
freq = 44100
bits = 16
stereo = True
buffer_size = 2048

audio.pre_open(frequency=freq, bits=bits, stereo=stereo, bufferSize=buffer_size)
pygame.init()
audio.open(frequency=freq, bits=bits, stereo=stereo, bufferSize=buffer_size)
print('mixer_config', pygame.mixer.get_init())
PY

------
https://chatgpt.com/codex/tasks/task_e_68dbeb9c4cf8832bbcbecc711f15d85a