### PR TITLE
Stop monkey patching pygame key names

### DIFF
--- a/src/fretsonfire/Dialogs.py
+++ b/src/fretsonfire/Dialogs.py
@@ -205,7 +205,7 @@ class GetKey(Layer, KeyListener):
       Theme.setSelectedColor(1 - v)
 
       if self.key is not None:
-        text = pygame.key.name(self.key).capitalize()
+        text = self.engine.input.formatKeyName(self.key).capitalize()
         pos = wrapText(font, (.1, (pos[1] + v) + .08 + v / 4), text)
       
     finally:

--- a/src/fretsonfire/Input.py
+++ b/src/fretsonfire/Input.py
@@ -93,8 +93,7 @@ class Input(Task):
     Audio.Music.setEndEvent(MusicFinished)
 
     # Custom key names
-    self.getSystemKeyName = pygame.key.name
-    pygame.key.name       = self.getKeyName
+    self._systemKeyName = pygame.key.name
 
   def reloadControls(self):
     self.controls = Controls()
@@ -169,7 +168,7 @@ class Input(Task):
     x, y = (v % 3) - 1, (v / 3) - 1
     return (id >> 8, (id >> 4) & 0xf, (x, y))
 
-  def getKeyName(self, id):
+  def formatKeyName(self, id):
     if id >= 0x30000:
       joy, axis, pos = self.decodeJoystickHat(id)
       return "Joy #%d, hat %d %s" % (joy + 1, axis, pos)
@@ -179,7 +178,11 @@ class Input(Task):
     elif id >= 0x10000:
       joy, but = self.decodeJoystickButton(id)
       return "Joy #%d, %s" % (joy + 1, chr(ord('A') + but))
-    return self.getSystemKeyName(id)
+    return self._systemKeyName(id)
+
+  # Backwards compatibility for callers using the old name.
+  def getKeyName(self, id):
+    return self.formatKeyName(id)
 
   def run(self, ticks):
     pygame.event.pump()

--- a/src/fretsonfire/Settings.py
+++ b/src/fretsonfire/Settings.py
@@ -103,7 +103,7 @@ class KeyConfigChoice(Menu.Choice):
         return getattr(pygame, k)
     o = self.config.prototype[self.section][self.option]
     v = self.config.get(self.section, self.option)
-    return "%s: %s" % (o.text, pygame.key.name(keycode(v)).capitalize())
+    return "%s: %s" % (o.text, self.engine.input.formatKeyName(keycode(v)).capitalize())
     
   def change(self):
     o = self.config.prototype[self.section][self.option]


### PR DESCRIPTION
## Summary
- keep pygame.key.name intact and expose Input.formatKeyName for joystick-aware labels
- update key configuration UI components to use the new helper

## Testing
- python -m compileall src/fretsonfire
- SDL_VIDEODRIVER=dummy python -m unittest src.fretsonfire.DialogTest *(fails: Unable to load OpenGL or GL library in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc00fae290832bb1cbd0b53ec8edf7