### PR TITLE
refactor: use explicit relative imports

### DIFF
--- a/src/fretsonfire/Credits.py
+++ b/src/fretsonfire/Credits.py
@@ -24,13 +24,13 @@ from OpenGL.GL import *
 from OpenGL.GLU import *
 import math
 
-from View import Layer
-from Input import KeyListener
-from Language import _
-import MainMenu
-import Song
-import Version
-import Player
+from .View import Layer
+from .Input import KeyListener
+from .Language import _
+from . import MainMenu
+from . import Song
+from . import Version
+from . import Player
 
 class Element:
   """A basic element in the credits scroller."""

--- a/src/fretsonfire/Data.py
+++ b/src/fretsonfire/Data.py
@@ -19,15 +19,15 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from Font import Font
-from Texture import Texture
-from Svg import SvgDrawing, SvgContext
-from Texture import Texture
-from Audio import Sound
-from Language import _
+from .Font import Font
+from .Texture import Texture
+from .Svg import SvgDrawing, SvgContext
+from .Texture import Texture
+from .Audio import Sound
+from .Language import _
 import random
-import Language
-import Config
+from . import Language
+from . import Config
 
 # these constants define a few customized letters in the default font
 STAR1 = '\x10'

--- a/src/fretsonfire/Debug.py
+++ b/src/fretsonfire/Debug.py
@@ -20,11 +20,11 @@
 #####################################################################
 
 from OpenGL.GL import *
-from View import Layer
+from .View import Layer
 
 import gc
 import threading
-import Log
+from . import Log
 
 class DebugLayer(Layer):
   """A layer for showing some debug information."""
@@ -95,7 +95,7 @@ class DebugLayer(Layer):
       self.engine.view.resetProjection()
 
   def gcDump(self):
-    import World
+    from . import World
     before = len(gc.get_objects())
     coll   = gc.collect()
     after  = len(gc.get_objects())

--- a/src/fretsonfire/DialogTest.py
+++ b/src/fretsonfire/DialogTest.py
@@ -20,9 +20,9 @@
 #####################################################################
 
 import unittest
-from GameEngine import GameEngine
-from Dialogs import getText
-from View import Layer
+from .GameEngine import GameEngine
+from .Dialogs import getText
+from .View import Layer
 
 class TestLayer(Layer):
   def __init__(self, engine):

--- a/src/fretsonfire/Dialogs.py
+++ b/src/fretsonfire/Dialogs.py
@@ -28,19 +28,19 @@ import math
 import os
 import fnmatch
 
-from View import Layer, BackgroundLayer
-from Input import KeyListener
-from Camera import Camera
-from Mesh import Mesh
-from Menu import Menu
-from Language import _
-from Texture import Texture
-import Theme
-import Log
-import Song
-import Data
-import Player
-import Guitar
+from .View import Layer, BackgroundLayer
+from .Input import KeyListener
+from .Camera import Camera
+from .Mesh import Mesh
+from .Menu import Menu
+from .Language import _
+from .Texture import Texture
+from . import Theme
+from . import Log
+from . import Song
+from . import Data
+from . import Player
+from . import Guitar
 
 def wrapText(font, pos, text, rightMargin = 0.9, scale = 0.002, visibility = 0.0, hide = 0, hidestring = ""):
   """

--- a/src/fretsonfire/Editor.py
+++ b/src/fretsonfire/Editor.py
@@ -25,18 +25,18 @@ from OpenGL.GLU import *
 import math
 import colorsys
 
-from View import Layer
-from Input import KeyListener
-from Song import loadSong, createSong, Note, difficulties, DEFAULT_LIBRARY
-from Guitar import Guitar, KEYS
-from Camera import Camera
-from Menu import Menu, Choice
-from Language import _
-import MainMenu
-import Dialogs
-import Player
-import Theme
-import Log
+from .View import Layer
+from .Input import KeyListener
+from .Song import loadSong, createSong, Note, difficulties, DEFAULT_LIBRARY
+from .Guitar import Guitar, KEYS
+from .Camera import Camera
+from .Menu import Menu, Choice
+from .Language import _
+from . import MainMenu
+from . import Dialogs
+from . import Player
+from . import Theme
+from . import Log
 import shutil, os, struct, wave, tempfile
 from struct import unpack
 

--- a/src/fretsonfire/Font.py
+++ b/src/fretsonfire/Font.py
@@ -24,7 +24,7 @@ import numpy
 from OpenGL.GL import *
 import sys
 
-from Texture import Texture, TextureAtlas, TextureAtlasFullException
+from .Texture import Texture, TextureAtlas, TextureAtlasFullException
 
 class Font:
   """A texture-mapped font."""

--- a/src/fretsonfire/FretsOnFire.py
+++ b/src/fretsonfire/FretsOnFire.py
@@ -36,11 +36,11 @@ codecs.register(lambda encoding: encodings.utf_8.getregentry())
 assert codecs.lookup("iso-8859-1")
 assert codecs.lookup("utf-8")
 
-from GameEngine import GameEngine
-from MainMenu import MainMenu
-import Log
-import Config
-import Version
+from .GameEngine import GameEngine
+from .MainMenu import MainMenu
+from . import Log
+from . import Config
+from . import Version
 
 def parse_args(argv):
   parser = argparse.ArgumentParser(

--- a/src/fretsonfire/GameEngine.py
+++ b/src/fretsonfire/GameEngine.py
@@ -25,25 +25,25 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from Engine import Engine, Task
-from Video import Video
-from Audio import Audio
-from View import View
-from Input import Input, KeyListener, SystemEventListener
-from Resource import Resource
-from Data import Data
-from Server import Server
-from Session import ClientSession
-from Svg import SvgContext, SvgDrawing, LOW_QUALITY, NORMAL_QUALITY, HIGH_QUALITY
-from Debug import DebugLayer
-from Language import _
-import Network
-import Log
-import Config
-import Dialogs
-import Theme
-import Version
-import Mod
+from .Engine import Engine, Task
+from .Video import Video
+from .Audio import Audio
+from .View import View
+from .Input import Input, KeyListener, SystemEventListener
+from .Resource import Resource
+from .Data import Data
+from .Server import Server
+from .Session import ClientSession
+from .Svg import SvgContext, SvgDrawing, LOW_QUALITY, NORMAL_QUALITY, HIGH_QUALITY
+from .Debug import DebugLayer
+from .Language import _
+from . import Network
+from . import Log
+from . import Config
+from . import Dialogs
+from . import Theme
+from . import Version
+from . import Mod
 
 # define configuration keys
 Config.define("engine", "tickrate",     float, 1.0)

--- a/src/fretsonfire/GameEngineTest.py
+++ b/src/fretsonfire/GameEngineTest.py
@@ -20,7 +20,7 @@
 #####################################################################
 
 import unittest
-from GameEngine import GameEngine
+from .GameEngine import GameEngine
 
 class EngineTest(unittest.TestCase):
   def testNetworking(self):

--- a/src/fretsonfire/GameResultsScene.py
+++ b/src/fretsonfire/GameResultsScene.py
@@ -19,15 +19,15 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from Scene import SceneServer, SceneClient
-from Menu import Menu
-import Player
-import Dialogs
-import Song
-import Data
-import Theme
-from Audio import Sound
-from Language import _
+from .Scene import SceneServer, SceneClient
+from .Menu import Menu
+from . import Player
+from . import Dialogs
+from . import Song
+from . import Data
+from . import Theme
+from .Audio import Sound
+from .Language import _
 
 import pygame
 import math

--- a/src/fretsonfire/GameTask.py
+++ b/src/fretsonfire/GameTask.py
@@ -19,13 +19,13 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from Input import KeyListener
-from Session import MessageHandler
-from Task import Task
-from Language import _
-import MainMenu
-import Svg
-import Dialogs
+from .Input import KeyListener
+from .Session import MessageHandler
+from .Task import Task
+from .Language import _
+from . import MainMenu
+from . import Svg
+from . import Dialogs
 
 class GameTask(Task, KeyListener, MessageHandler):
   def __init__(self, engine, session, drawMiniViews = False):

--- a/src/fretsonfire/Guitar.py
+++ b/src/fretsonfire/Guitar.py
@@ -19,10 +19,10 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-import Player
-from Song import Note, Tempo
-from Mesh import Mesh
-import Theme
+from . import Player
+from .Song import Note, Tempo
+from .Mesh import Mesh
+from . import Theme
 
 from OpenGL.GL import *
 import math

--- a/src/fretsonfire/GuitarScene.py
+++ b/src/fretsonfire/GuitarScene.py
@@ -19,19 +19,19 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from Scene import SceneServer, SceneClient
-from Song import Note, TextEvent, PictureEvent, loadSong
-from Menu import Menu
-from Guitar import Guitar, KEYS
-from Language import _
-import Player
-import Dialogs
-import Data
-import Theme
-import View
-import Audio
-import Stage
-import Settings
+from .Scene import SceneServer, SceneClient
+from .Song import Note, TextEvent, PictureEvent, loadSong
+from .Menu import Menu
+from .Guitar import Guitar, KEYS
+from .Language import _
+from . import Player
+from . import Dialogs
+from . import Data
+from . import Theme
+from . import View
+from . import Audio
+from . import Stage
+from . import Settings
 
 import math
 import pygame

--- a/src/fretsonfire/Input.py
+++ b/src/fretsonfire/Input.py
@@ -20,11 +20,11 @@
 #####################################################################
 
 import pygame
-import Log
-import Audio
+from . import Log
+from . import Audio
 
-from Task import Task
-from Player import Controls
+from .Task import Task
+from .Player import Controls
 
 class KeyListener:
   def keyPressed(self, key, unicode):

--- a/src/fretsonfire/Lobby.py
+++ b/src/fretsonfire/Lobby.py
@@ -24,15 +24,15 @@ from OpenGL.GL import *
 import math
 import colorsys
 
-from View import Layer
-from Input import KeyListener
-from GameTask import GameTask
-from Session import MessageHandler
-from Language import _
-import MainMenu
-import Dialogs
-import Player
-import Song
+from .View import Layer
+from .Input import KeyListener
+from .GameTask import GameTask
+from .Session import MessageHandler
+from .Language import _
+from . import MainMenu
+from . import Dialogs
+from . import Player
+from . import Song
 
 class Lobby(Layer, KeyListener, MessageHandler):
   def __init__(self, engine, session, singlePlayer = False, songName = None):

--- a/src/fretsonfire/MainMenu.py
+++ b/src/fretsonfire/MainMenu.py
@@ -23,17 +23,17 @@ from OpenGL.GL import *
 import math
 import socket
 
-from View import BackgroundLayer
-from Menu import Menu
-from Editor import Editor, Importer, GHImporter
-from Credits import Credits
-from Lobby import Lobby
-from Svg import SvgDrawing
-from Language import _
-import Dialogs
-import Config
-import Audio
-import Settings
+from .View import BackgroundLayer
+from .Menu import Menu
+from .Editor import Editor, Importer, GHImporter
+from .Credits import Credits
+from .Lobby import Lobby
+from .Svg import SvgDrawing
+from .Language import _
+from . import Dialogs
+from . import Config
+from . import Audio
+from . import Settings
 
 class MainMenu(BackgroundLayer):
   def __init__(self, engine, songName = None):

--- a/src/fretsonfire/Menu.py
+++ b/src/fretsonfire/Menu.py
@@ -23,12 +23,12 @@ import pygame
 from OpenGL.GL import *
 import math
 
-from View import Layer
-from Input import KeyListener
-import Data
-import Theme
-import Dialogs
-import Player
+from .View import Layer
+from .Input import KeyListener
+from . import Data
+from . import Theme
+from . import Dialogs
+from . import Player
 
 class Choice:
   def __init__(self, text, callback, values = None, valueIndex = 0):

--- a/src/fretsonfire/MenuTest.py
+++ b/src/fretsonfire/MenuTest.py
@@ -20,8 +20,8 @@
 #####################################################################
 
 import unittest
-from GameEngine import GameEngine
-from Menu import Menu
+from .GameEngine import GameEngine
+from .Menu import Menu
 
 subMenu = [
   ("Bar 1", lambda: 0),

--- a/src/fretsonfire/Mesh.py
+++ b/src/fretsonfire/Mesh.py
@@ -21,7 +21,7 @@
 
 from OpenGL.GL import *
 
-import Collada
+from . import Collada
 
 class Mesh:
   def __init__(self, fileName):

--- a/src/fretsonfire/Mod.py
+++ b/src/fretsonfire/Mod.py
@@ -20,8 +20,8 @@
 #####################################################################
 
 import os
-import Config
-from Language import _
+from . import Config
+from .Language import _
 
 def _getModPath(engine):
   return engine.resource.fileName("mods")
@@ -40,7 +40,7 @@ def getAvailableMods(engine):
   try:
     dirList = os.listdir(modPath)
   except OSError:
-    import Log
+    from . import Log
     Log.warn("Could not find mods directory")
     return []
   return [m for m in dirList if os.path.isdir(os.path.join(modPath, m)) and not m.startswith(".")]

--- a/src/fretsonfire/Scene.py
+++ b/src/fretsonfire/Scene.py
@@ -19,14 +19,14 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from Player import Player
-from View import BackgroundLayer
-from Session import MessageHandler, Message
-from Input import KeyListener
-from Camera import Camera
-import Network
-import Player
-import Config
+from .Player import Player
+from .View import BackgroundLayer
+from .Session import MessageHandler, Message
+from .Input import KeyListener
+from .Camera import Camera
+from . import Network
+from . import Player
+from . import Config
 
 from OpenGL.GL import *
 from OpenGL.GLU import *

--- a/src/fretsonfire/SceneTest.py
+++ b/src/fretsonfire/SceneTest.py
@@ -22,8 +22,8 @@
 import unittest
 import time
 
-from Scene import Scene
-from Resource import Resource
+from .Scene import Scene
+from .Resource import Resource
 
 class CityScene(Scene):
   def __init__(self, id = None, manager = None):

--- a/src/fretsonfire/Settings.py
+++ b/src/fretsonfire/Settings.py
@@ -19,12 +19,12 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-import Menu
-from Language import _
-import Dialogs
-import Config
-import Mod
-import Audio
+from . import Menu
+from .Language import _
+from . import Dialogs
+from . import Config
+from . import Mod
+from . import Audio
 
 import pygame
 

--- a/src/fretsonfire/SongChoosingScene.py
+++ b/src/fretsonfire/SongChoosingScene.py
@@ -19,12 +19,12 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from Scene import SceneServer, SceneClient
-import Player
-import Dialogs
-import Song
-import Config
-from Language import _
+from .Scene import SceneServer, SceneClient
+from . import Player
+from . import Dialogs
+from . import Song
+from . import Config
+from .Language import _
 
 # save chosen song into config file
 Config.define("game", "selected_library",  str, "")

--- a/src/fretsonfire/Stage.py
+++ b/src/fretsonfire/Stage.py
@@ -22,8 +22,8 @@
 from configparser import ConfigParser
 from OpenGL.GL import *
 import math
-import Log
-import Theme
+from . import Log
+from . import Theme
 
 class Layer(object):
   """

--- a/src/fretsonfire/Svg.py
+++ b/src/fretsonfire/Svg.py
@@ -26,9 +26,9 @@ from OpenGL.GL import *
 from numpy import reshape, dot, transpose, identity, zeros, float32
 from math import sin, cos
 
-import Log
-import Config
-from Texture import Texture, TextureException
+from . import Log
+from . import Config
+from .Texture import Texture, TextureException
 
 # Amanith support is now deprecated
 #try:
@@ -39,7 +39,7 @@ from Texture import Texture, TextureException
 #  Log.warn("PyAmanith not found, SVG support disabled.")
 #  import DummyAmanith as amanith
 #  haveAmanith    = False
-import DummyAmanith as amanith
+from . import DummyAmanith as amanith
 haveAmanith = True
 
 # Add support for 'foo in attributes' syntax

--- a/src/fretsonfire/SvgTest.py
+++ b/src/fretsonfire/SvgTest.py
@@ -20,8 +20,8 @@
 #####################################################################
 
 import unittest
-from GameEngine import GameEngine
-from Texture import Texture
+from .GameEngine import GameEngine
+from .Texture import Texture
 
 from OpenGL.GL import *
 from OpenGL.GLU import *

--- a/src/fretsonfire/TestAll.py
+++ b/src/fretsonfire/TestAll.py
@@ -25,7 +25,7 @@
 import sys
 import os
 import unittest
-import Config
+from . import Config
 
 tests = []
 

--- a/src/fretsonfire/Texture.py
+++ b/src/fretsonfire/Texture.py
@@ -21,8 +21,8 @@
 
 from __future__ import division
 
-import Log
-import Config
+from . import Log
+from . import Config
 from PIL import Image
 import pygame
 from io import BytesIO

--- a/src/fretsonfire/Video.py
+++ b/src/fretsonfire/Video.py
@@ -22,7 +22,7 @@
 import pygame
 from OpenGL.GL import glEnable
 from OpenGL.GL.ARB.multisample import GL_MULTISAMPLE_ARB
-import Log
+from . import Log
 
 class Video:
   def __init__(self, caption = "Game"):

--- a/src/fretsonfire/VideoTest.py
+++ b/src/fretsonfire/VideoTest.py
@@ -20,7 +20,7 @@
 #####################################################################
 
 import unittest
-from Video import Video
+from .Video import Video
 
 class VideoTest(unittest.TestCase):
   def testSetMode(self):

--- a/src/fretsonfire/View.py
+++ b/src/fretsonfire/View.py
@@ -34,9 +34,9 @@ from OpenGL.GL import (
   glViewport,
 )
 
-import Log
+from . import Log
 
-from Task import Task
+from .Task import Task
 
 class Layer(Task):
   def render(self, visibility, topMost):

--- a/src/fretsonfire/ViewTest.py
+++ b/src/fretsonfire/ViewTest.py
@@ -20,8 +20,8 @@
 #####################################################################
 
 import unittest
-from GameEngine import GameEngine
-from View import Layer
+from .GameEngine import GameEngine
+from .View import Layer
 
 class TestLayer(Layer):
   def __init__(self):

--- a/src/fretsonfire/midi/MidiFileParser.py
+++ b/src/fretsonfire/midi/MidiFileParser.py
@@ -188,8 +188,8 @@ if __name__ == '__main__':
 #    
 #    
 #    # do parsing
-    from midi.MidiToText import MidiToText
-    from midi.RawInstreamFile import RawInstreamFile
+    from .MidiToText import MidiToText
+    from .RawInstreamFile import RawInstreamFile
 
     midi_in = MidiFileParser(RawInstreamFile(test_file), MidiToText())
     midi_in.parseMThdChunk()


### PR DESCRIPTION
## Summary
- replace implicit relative imports with explicit relative imports across the `fretsonfire` package to ensure Python 3 compatibility
- update midi utility references in documentation strings to use explicit relative imports as well

## Testing
- python -m pytest *(fails: OpenGL runtime dependency missing in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d773dd8832ba5ee9ea012e56faa