### PR TITLE
fix: import soundfile at module scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "numpy>=1.20",
     "Pillow>=9.0",
     "pyasyncore>=1.0",
+    "soundfile>=0.12",
     "skia-python>=87.0",
 ]
 

--- a/src/fretsonfire/locale/fretsonfire.pot
+++ b/src/fretsonfire/locale/fretsonfire.pot
@@ -373,11 +373,7 @@ msgid "No songs could be imported, sorry. Check the log files for more informati
 msgstr ""
 
 #: Editor.py:797
-msgid "Ogg Vorbis encoder (oggenc.exe) not found. Please install it to the game directory and try again."
-msgstr ""
-
-#: Editor.py:799
-msgid "Ogg Vorbis encoder (oggenc) not found. Please install it and try again."
+msgid "Ogg Vorbis encoding support is unavailable. Ensure SoundFile and libsndfile include Vorbis support, then try again."
 msgstr ""
 
 #: Editor.py:803


### PR DESCRIPTION
## Summary
- import soundfile at module scope so encoder helpers assume availability
- remove redundant runtime imports from the Ogg encoding helpers

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee5d041944832b8a079a756ab8dcf1